### PR TITLE
export collections in package namespace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: msigdb
 Type: Package
 Title: MSigDB Gene Set Collections
-Version: 0.1.2
+Version: 0.1.3
 Date: 2015-07-14
 Author: Minghui Wang
 Maintainer: Minghui Wang <m.h.wang@live.com>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,6 +4,7 @@ export(
 	read.gaf,
 	write.gmt,
 	convert.msigdb.genesets,
+	msigdb.collections,
 	msigdb.genesets,
 	msigdb.version
 )

--- a/R/msigdb.collections.R
+++ b/R/msigdb.collections.R
@@ -1,0 +1,1 @@
+msigdb.collections=c('C1.CYTO','C2.CGP','C2.CP','C3.MIR','C3.TFT','C4.CGN','C4.CM','C5.BP','C5.CC','C5.MF','C6.ONCOGENE','C7.IMMUNE','CH.HALLMARK')

--- a/R/msigdb.genesets.R
+++ b/R/msigdb.genesets.R
@@ -3,15 +3,14 @@ msigdb.genesets=function(sets=NULL, type=c('symbols', 'entrez'),species=c('human
 	type=match.arg(type)
 	species=match.arg(species)
 	if(species=='mouse' && type=='entrez') stop('Only symbols type is supported for mouse\n')
-	collections=c('C1.CYTO','C2.CGP','C2.CP','C3.MIR','C3.TFT','C4.CGN','C4.CM','C5.BP','C5.CC','C5.MF','C6.ONCOGENE','C7.IMMUNE','CH.HALLMARK')
 	gmtfiles=paste(c(
 		C1.CYTO='c1.all', C2.CGP='c2.cgp', C2.CP='c2.cp', C3.MIR='c3.mir', C3.TFT='c3.tft', C4.CGN='c4.cgn', C4.CM='c4.cm',
 		C5.BP='c5.bp', C5.CC='c5.cc', C5.MF='c5.mf', C6.ONCOGENE='c6.all', C7.IMMUNE='c7.all',CH.HALLMARK='h.all'
 	),msigdb.version(),type,'gmt',sep='.')
 	gmtfiles=paste(species,gmtfiles,sep='/')
-	names(gmtfiles)=collections
-	if(is.null(sets)) sets=collections
-	if(! all(sets %in% collections)) stop('Invalid values for argument sets\n')
+	names(gmtfiles)=msigdb.collections
+	if(is.null(sets)) sets=msigdb.collections
+	if(! all(sets %in% msigdb.collections)) stop('Invalid values for argument sets\n')
 	obj=NULL
 	for(s in sets){
 		#f=file.path(system.file("extdata", package="msigdb"),gmtfiles[s])

--- a/man/msigdb.collections.Rd
+++ b/man/msigdb.collections.Rd
@@ -1,0 +1,7 @@
+\name{msigdb.collections}
+\docType{package}
+\alias{msigdb.collections}
+\title{msigdb.collections}
+\description{
+  Character vector of available gene set collections
+}


### PR DESCRIPTION
Hi,

It would be nice if the available `msigdb.collections` could be accessed from the package namespace.

The pull request provides this.